### PR TITLE
Migrate to Vue 3 draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,13 @@
         "dropbox": "^10.26.0",
         "lamejs": "github:zhuker/lamejs",
         "register-service-worker": "^1.7.1",
-        "vue": "v2-latest",
-        "vuex": "^3.6.2"
+        "vue": "^3.1.1",
+        "vuex": "^4.0.1"
       },
       "devDependencies": {
         "@types/webmidi": "^2.0.6",
-        "@vitejs/plugin-vue2": "^2.2.0",
+        "@vitejs/plugin-vue": "^4.5.1",
+        "@vue/compiler-sfc": "^3.1.1",
         "audio-encoder": "1.0.4",
         "axios": "^0.24.0",
         "bowser": "^2.11.0",
@@ -38,7 +39,7 @@
         "vite": "^4.1.4",
         "vite-plugin-static-copy": "^0.13.1",
         "vitest": "^0.29.3",
-        "vue-i18n": "^8.26.7",
+        "vue-i18n": "^9.1.6",
         "vue-js-toggle-button": "^1.3.3",
         "vue-knob-control": "^1.6.0",
         "vue-select": "^3.11.2",
@@ -55,6 +56,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -567,6 +579,50 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@intlify/core-base": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.8.0.tgz",
+      "integrity": "sha512-UxaSZVZ1DwqC/CltUZrWZNaWNhfmKtfyV4BJSt/Zt4Or/fZs1iFj0B+OekYk1+MRHfIOe3+x00uXGQI4PbO/9g==",
+      "dev": true,
+      "dependencies": {
+        "@intlify/message-compiler": "9.8.0",
+        "@intlify/shared": "9.8.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.8.0.tgz",
+      "integrity": "sha512-McnYWhcoYmDJvssVu6QGR0shqlkJuL1HHdi5lK7fNqvQqRYaQ4lSLjYmZxwc8tRNMdIe9/KUKfyPxU9M6yCtNQ==",
+      "dev": true,
+      "dependencies": {
+        "@intlify/shared": "9.8.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.8.0.tgz",
+      "integrity": "sha512-TmgR0RCLjzrSo+W3wT0ALf9851iFMlVI9EYNGeWvZFUQTAJx0bvfsMlPdgVtV1tDNRiAfhkFsMKu6jtUY1ZLKQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
@@ -642,12 +698,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -752,17 +805,17 @@
       "integrity": "sha512-sfS0A5IryqmBrUpcGPipEPeFdpqmZzP6b6lZFxHKgz5n2Vhzh4yJ5P2TvoDUhDjqJyv0Y25ng0Qodgo2Vu08ug==",
       "dev": true
     },
-    "node_modules/@vitejs/plugin-vue2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-2.2.0.tgz",
-      "integrity": "sha512-1km7zEuZ/9QRPvzXSjikbTYGQPG86Mq1baktpC4sXqsXlb02HQKfi+fl8qVS703JM7cgm24Ga9j+RwKmvFn90A==",
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.1.tgz",
+      "integrity": "sha512-DaUzYFr+2UGDG7VSSdShKa9sIWYBa1LL8KC0MNOf2H5LjcTPjob0x8LbkqXWmAtbANJCkpiQTj66UVcQkN2s3g==",
       "dev": true,
       "engines": {
-        "node": "^14.18.0 || >= 16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0",
-        "vue": "^2.7.0-0"
+        "vite": "^4.0.0 || ^5.0.0",
+        "vue": "^3.2.25"
       }
     },
     "node_modules/@vitest/expect": {
@@ -823,34 +876,112 @@
         "pretty-format": "^27.5.1"
       }
     },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+    "node_modules/@vue/compiler-core": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.10.tgz",
+      "integrity": "sha512-doe0hODR1+i1menPkRzJ5MNR6G+9uiZHIknK3Zn5OcIztu6GGw7u0XUzf3AgB8h/dfsZC9eouzoLo3c3+N/cVA==",
       "dependencies": {
-        "@babel/parser": "^7.18.4",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.10",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
-      "bin": {
-        "parser": "bin/babel-parser.js"
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.10.tgz",
+      "integrity": "sha512-NCrqF5fm10GXZIK0GrEAauBqdy+F2LZRt3yNHzrYjpYBuRssQbuPLtSnSNjyR9luHKkWSH8we5LMB3g+4z2HvA==",
+      "dependencies": {
+        "@vue/compiler-core": "3.3.10",
+        "@vue/shared": "3.3.10"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.10.tgz",
+      "integrity": "sha512-xpcTe7Rw7QefOTRFFTlcfzozccvjM40dT45JtrE3onGm/jBLZ0JhpKu3jkV7rbDFLeeagR/5RlJ2Y9SvyS0lAg==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.10",
+        "@vue/compiler-dom": "3.3.10",
+        "@vue/compiler-ssr": "3.3.10",
+        "@vue/reactivity-transform": "3.3.10",
+        "@vue/shared": "3.3.10",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.10.tgz",
+      "integrity": "sha512-12iM4jA4GEbskwXMmPcskK5wImc2ohKm408+o9iox3tfN9qua8xL0THIZtoe9OJHnXP4eOWZpgCAAThEveNlqQ==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.10",
+        "@vue/shared": "3.3.10"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+      "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.10.tgz",
+      "integrity": "sha512-H5Z7rOY/JLO+e5a6/FEXaQ1TMuOvY4LDVgT+/+HKubEAgs9qeeZ+NhADSeEtrNQeiKLDuzeKc8v0CUFpB6Pqgw==",
+      "dependencies": {
+        "@vue/shared": "3.3.10"
+      }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.10.tgz",
+      "integrity": "sha512-0xBdk+CKHWT+Gev8oZ63Tc0qFfj935YZx+UAynlutnrDZ4diFCVFMWixn65HzjE3S1iJppWOo6Tt1OzASH7VEg==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.10",
+        "@vue/shared": "3.3.10",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.10.tgz",
+      "integrity": "sha512-DZ0v31oTN4YHX9JEU5VW1LoIVgFovWgIVb30bWn9DG9a7oA415idcwsRNNajqTx8HQJyOaWfRKoyuP2P2TYIag==",
+      "dependencies": {
+        "@vue/reactivity": "3.3.10",
+        "@vue/shared": "3.3.10"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.10.tgz",
+      "integrity": "sha512-c/jKb3ny05KJcYk0j1m7Wbhrxq7mZYr06GhKykDMNRRR9S+/dGT8KpHuNQjv3/8U4JshfkAk6TpecPD3B21Ijw==",
+      "dependencies": {
+        "@vue/runtime-core": "3.3.10",
+        "@vue/shared": "3.3.10",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.10.tgz",
+      "integrity": "sha512-0i6ww3sBV3SKlF3YTjSVqKQ74xialMbjVYGy7cOTi7Imd8ediE7t72SK3qnvhrTAhOvlQhq6Bk6nFPdXxe0sAg==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.3.10",
+        "@vue/shared": "3.3.10"
       },
-      "engines": {
-        "node": ">=6.0.0"
+      "peerDependencies": {
+        "vue": "3.3.10"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/@vue/shared": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.10.tgz",
+      "integrity": "sha512-2y3Y2J1a3RhFa0WisHvACJR2ncvWiVHcP8t0Inxo+NKz+8RKO4ZV8eZgCxRgQoA6ITfV12L4E6POOL9HOU5nqw=="
     },
     "node_modules/@wasm-audio-decoders/common": {
       "version": "1.0.0",
@@ -1274,9 +1405,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/dashify": {
       "version": "2.0.0",
@@ -2070,6 +2201,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2752,6 +2888,17 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/media-encoder-host": {
       "version": "8.0.67",
       "resolved": "https://registry.npmjs.org/media-encoder-host/-/media-encoder-host-8.0.67.tgz",
@@ -2893,9 +3040,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -3067,9 +3214,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3085,7 +3232,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -3656,7 +3803,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3915,12 +4062,23 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.10.tgz",
+      "integrity": "sha512-zg6SIXZdTBwiqCw/1p+m04VyHjLfwtjwz8N57sPaBhEex31ND0RYECVOC1YrRwMRmxFf5T1dabl6SGUbMKKuVw==",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.14",
-        "csstype": "^3.1.0"
+        "@vue/compiler-dom": "3.3.10",
+        "@vue/compiler-sfc": "3.3.10",
+        "@vue/runtime-dom": "3.3.10",
+        "@vue/server-renderer": "3.3.10",
+        "@vue/shared": "3.3.10"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -3979,10 +4137,24 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.27.0.tgz",
-      "integrity": "sha512-SX35iJHL5PJ4Gfh0Mo/q0shyHiI2V6Zkh51c+k8E9O1RKv5BQyYrCxRzpvPrsIOJEnLaeiovet3dsUB0e/kDzw==",
-      "dev": true
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.8.0.tgz",
+      "integrity": "sha512-Izho+6PYjejsTq2mzjcRdBZ5VLRQoSuuexvR8029h5CpN03FYqiqBrShMyf2I1DKkN6kw/xmujcbvC+4QybpsQ==",
+      "dev": true,
+      "dependencies": {
+        "@intlify/core-base": "9.8.0",
+        "@intlify/shared": "9.8.0",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/vue-js-toggle-button": {
       "version": "1.3.3",
@@ -4018,11 +4190,14 @@
       }
     },
     "node_modules/vuex": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+      "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
       "peerDependencies": {
-        "vue": "^2.0.0"
+        "vue": "^3.2.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "dropbox": "^10.26.0",
     "lamejs": "github:zhuker/lamejs",
     "register-service-worker": "^1.7.1",
-    "vue": "v2-latest",
-    "vuex": "^3.6.2"
+    "vue": "^3.1.1",
+    "vuex": "^4.0.1"
   },
   "devDependencies": {
     "@types/webmidi": "^2.0.6",
-    "@vitejs/plugin-vue2": "^2.2.0",
+    "@vitejs/plugin-vue": "^4.5.1",
+    "@vue/compiler-sfc": "^3.1.1",
     "audio-encoder": "1.0.4",
     "axios": "^0.24.0",
     "bowser": "^2.11.0",
@@ -44,7 +45,7 @@
     "vite": "^4.1.4",
     "vite-plugin-static-copy": "^0.13.1",
     "vitest": "^0.29.3",
-    "vue-i18n": "^8.26.7",
+    "vue-i18n": "^9.1.6",
     "vue-js-toggle-button": "^1.3.3",
     "vue-knob-control": "^1.6.0",
     "vue-select": "^3.11.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dropbox": "^10.26.0",
     "lamejs": "github:zhuker/lamejs",
     "register-service-worker": "^1.7.1",
-    "vue": "^3.1.1",
+    "vue": "^3.2.25",
     "vuex": "^4.0.1"
   },
   "devDependencies": {

--- a/src/components/advanced-pattern-editor/advanced-pattern-editor.vue
+++ b/src/components/advanced-pattern-editor/advanced-pattern-editor.vue
@@ -90,6 +90,7 @@ type ClonedPatternDef = {
 };
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     data: () => ({
         firstPattern: 1,
@@ -123,7 +124,8 @@ export default {
             this.$refs.firstPatternInput.focus();
         });
     },
-    beforeDestroy(): void {
+
+    beforeUnmount(): void {
         this.suspendKeyboardService( false );
     },
     methods: {

--- a/src/components/chord-generator-window/chord-generator-window.vue
+++ b/src/components/chord-generator-window/chord-generator-window.vue
@@ -74,6 +74,7 @@ import SelectBox from "@/components/forms/select-box.vue";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     components: {
         SelectBox,
@@ -104,7 +105,7 @@ export default {
     created() {
         KeyboardService.setListener( this.handleKeyboardInput.bind( this ));
     },
-    beforeDestroy() {
+    beforeUnmount() {
         KeyboardService.setListener( null );
     },
     methods: {

--- a/src/components/dialog-window/dialog-window.vue
+++ b/src/components/dialog-window/dialog-window.vue
@@ -83,7 +83,7 @@ export default {
     created(): void {
         KeyboardService.setListener( this.handleKey.bind( this ));
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         KeyboardService.reset();
     },
     methods: {

--- a/src/components/forms/assignable-control-input/assignable-toggle-control.vue
+++ b/src/components/forms/assignable-control-input/assignable-toggle-control.vue
@@ -53,6 +53,7 @@ import AssignableInput from "./assignable-control-input";
 import messages from "./messages.json";
 
 export default {
+    emits: ["input"],
     i18n: { messages },
     components: {
         ToggleButton

--- a/src/components/forms/form-list-item.vue
+++ b/src/components/forms/form-list-item.vue
@@ -30,6 +30,7 @@
 
 <script>
 export default {
+    emits: ["input"],
     props: {
         // the bound v-model
         value: {

--- a/src/components/forms/select-box.vue
+++ b/src/components/forms/select-box.vue
@@ -42,6 +42,7 @@ import "vue-select/dist/vue-select.css";
 import { createPopper } from '@popperjs/core'
 
 export default {
+    emits: ["input"],
     props: {
         value: {
             type: [ String, Number ],

--- a/src/components/instrument-editor/components/module-editor/module-editor.vue
+++ b/src/components/instrument-editor/components/module-editor/module-editor.vue
@@ -196,6 +196,7 @@ import { clone } from "@/utils/object-util";
 import messages from "./messages.json";
 
 export default {
+    emits: ["invalidate"],
     i18n: { messages },
     components: {
         SelectBox,

--- a/src/components/instrument-editor/components/oscillator-editor/oscillator-editor.vue
+++ b/src/components/instrument-editor/components/oscillator-editor/oscillator-editor.vue
@@ -181,6 +181,7 @@ import { clone } from "@/utils/object-util";
 import messages from "./messages.json";
 
 export default {
+    emits: ["invalidate"],
     i18n: { messages },
     components: {
         SelectBox,

--- a/src/components/instrument-editor/instrument-editor.vue
+++ b/src/components/instrument-editor/instrument-editor.vue
@@ -239,7 +239,7 @@ export default {
         this.instrument = this.selectedInstrument; // last active instrument in editor will be opened
         this.publishMessage( PubSubMessages.INSTRUMENT_EDITOR_OPENED );
     },
-    destroyed() {
+    unmounted() {
         this.setMidiAssignMode( false );
     },
     methods: {

--- a/src/components/jam-mode-editor/components/piano-roll/components/piano-roll-row.vue
+++ b/src/components/jam-mode-editor/components/piano-roll/components/piano-roll-row.vue
@@ -110,6 +110,7 @@ let dataTransfer: DataTransfer;
  * the DOM API allows for easy pointer event manipulation and the result is performant enough.
  */
 export default {
+    emits: ["note:delete", "note:resize", "note:move", "note:add"],
     props: {
         note: {
             type: String,
@@ -178,7 +179,7 @@ export default {
     created(): void {
         this.dragListeners = [] as DragListener[];
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         this.removeListeners();
     },
     methods: {

--- a/src/components/jam-mode-editor/components/piano-roll/piano-roll.vue
+++ b/src/components/jam-mode-editor/components/piano-roll/piano-roll.vue
@@ -316,14 +316,14 @@ export default {
             const { activePatternIndex, selectedInstrument } = this;
             const act = (): void => {
                 const pattern = this.activeSong.patterns[ activePatternIndex ];
-                this.$set( pattern.channels[ selectedInstrument ], event.step, EventFactory.create( selectedInstrument, "", 0, ACTION_NOTE_OFF ));
+                pattern.channels[ selectedInstrument ][event.step] = EventFactory.create( selectedInstrument, "", 0, ACTION_NOTE_OFF );
             };
             act();
             this.saveState({
                 undo: (): void => {
                     const pattern = this.activeSong.patterns[ activePatternIndex ];
                     EventUtil.setPosition( event.event, pattern, event.step, this.activeSong.meta.tempo );
-                    this.$set( pattern.channels[ selectedInstrument ], event.step, event.event );
+                    pattern.channels[ selectedInstrument ][event.step] = event.event;
                 },
                 redo: act,
             });

--- a/src/components/jam-mode-editor/jam-mode-editor.vue
+++ b/src/components/jam-mode-editor/jam-mode-editor.vue
@@ -93,7 +93,7 @@ export default {
             this.$store.commit( "setShowNoteEntry", true );
         }
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         KeyboardService.setListener( null );
     },
     methods: {

--- a/src/components/jam-mode-instrument-editor/jam-mode-instrument-editor.vue
+++ b/src/components/jam-mode-instrument-editor/jam-mode-instrument-editor.vue
@@ -38,6 +38,7 @@ import InstrumentEditor from "@/components/instrument-editor/instrument-editor.v
 import NoteEntryEditor from "@/components/note-entry-editor/note-entry-editor.vue";
 
 export default {
+    emits: ["close"],
     components: {
         InstrumentEditor,
         NoteEntryEditor,

--- a/src/components/loader.vue
+++ b/src/components/loader.vue
@@ -53,7 +53,7 @@ export default {
             this.show = true;
         }, DELAY );
     },
-    beforeDestroy() {
+    beforeUnmount() {
         window.clearTimeout( this.to );
     }
 };

--- a/src/components/midi-export-window/midi-export-window.vue
+++ b/src/components/midi-export-window/midi-export-window.vue
@@ -78,6 +78,7 @@ import { toFileName } from "@/utils/string-util";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     data: () => ({
         firstOrderIndex : 1,
@@ -109,7 +110,7 @@ export default {
             this.$refs.firstPatternInput.focus();
         });
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         this.suspendKeyboardService( false );
     },
     methods: {

--- a/src/components/midi-preset-manager/midi-preset-manager.vue
+++ b/src/components/midi-preset-manager/midi-preset-manager.vue
@@ -81,6 +81,7 @@ import { type MIDIPairingPreset } from "@/store/modules/midi-module";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     data: () => ({
         newPresetName: "",

--- a/src/components/mixer/components/channel-strip.vue
+++ b/src/components/mixer/components/channel-strip.vue
@@ -248,7 +248,7 @@ export default {
         };
         renderLoop();
     },
-    destroyed(): void {
+    unmounted(): void {
         cancelAnimationFrame( this.renderCycle );
     },
     methods: {

--- a/src/components/mixer/components/eq-control.vue
+++ b/src/components/mixer/components/eq-control.vue
@@ -38,6 +38,7 @@
 import KnobControl from "vue-knob-control";
 
 export default {
+    emits: ["input"],
     components: {
         KnobControl
     },

--- a/src/components/mixer/mixer.vue
+++ b/src/components/mixer/mixer.vue
@@ -69,7 +69,7 @@ export default {
         // connect the AnalyserNodes to the all instrument channels
         applyModules( this.activeSong, true );
     },
-    destroyed() {
+    unmounted() {
         // disconnect the AnalyserNodes
         applyModules( this.activeSong, false );
     },

--- a/src/components/module-param-editor/module-param-editor.vue
+++ b/src/components/module-param-editor/module-param-editor.vue
@@ -174,6 +174,7 @@ const DEFAULT_MODULE = VOLUME;
 let lastValueTypeAction = 0, lastValueChar = 0;
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     components: {
         FormListItem,
@@ -225,7 +226,7 @@ export default {
 
         this.supportsPanning = supports("panning");
     },
-    beforeDestroy() {
+    beforeUnmount() {
         KeyboardService.reset();
     },
     methods: {

--- a/src/components/note-entry-editor/note-entry-editor.vue
+++ b/src/components/note-entry-editor/note-entry-editor.vue
@@ -196,7 +196,7 @@ export default {
         //     this.largeView = true;
         // }
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         NoteInputHandler.unregisterHandler();
         this.killAllNotes();
     },

--- a/src/components/optimization-window/optimization-window.vue
+++ b/src/components/optimization-window/optimization-window.vue
@@ -57,6 +57,7 @@ import EventUtil from "@/utils/event-util";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     computed: {
         ...mapGetters([

--- a/src/components/pattern-order-list/components/pattern-order-entry.vue
+++ b/src/components/pattern-order-list/components/pattern-order-entry.vue
@@ -45,6 +45,7 @@
 
 <script lang="ts">
 export default {
+    emits: ["select", "toggle-edit-mode"],
     props: {
         name: {
             type: String,

--- a/src/components/pattern-to-order-conversion-window/pattern-to-order-conversion-window.vue
+++ b/src/components/pattern-to-order-conversion-window/pattern-to-order-conversion-window.vue
@@ -55,6 +55,7 @@ import { convertLegacy } from "@/utils/pattern-order-util";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     data: () => ({
         newPatternIndex: 0,

--- a/src/components/sample-display/sample-display.vue
+++ b/src/components/sample-display/sample-display.vue
@@ -24,7 +24,7 @@
     <canvas
         ref="waveformDisplay"
         class="sample-canvas"
-        v-on="$listeners"
+        
     ></canvas>
 </template>
 

--- a/src/components/sample-editor/sample-editor.vue
+++ b/src/components/sample-editor/sample-editor.vue
@@ -412,7 +412,7 @@ export default {
         }
         this.debouncedSlice = debounce( this.sliceSample.bind( this ), 50 );
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         this.stopPlayback();
     },
     methods: {

--- a/src/components/sample-recorder/sample-recorder.vue
+++ b/src/components/sample-recorder/sample-recorder.vue
@@ -83,6 +83,7 @@ const C = Math.PI * 180; // 180 == twice the circle R attribute value
 const MAX_DURATION = 10000;
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     components: {
         SelectBox,

--- a/src/components/settings-window/settings-window.vue
+++ b/src/components/settings-window/settings-window.vue
@@ -231,7 +231,7 @@ export default {
             });
         },
     },
-    destroyed(): void {
+    unmounted(): void {
         if ( this.changeListener ) {
             zMIDI.removeChangeListener( this.changeListener );
         }

--- a/src/components/shared-song-window/shared-song-window.vue
+++ b/src/components/shared-song-window/shared-song-window.vue
@@ -57,6 +57,7 @@ import { applyModules } from "@/services/audio-service";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     computed: {
         ...mapGetters([
@@ -77,7 +78,7 @@ export default {
         };
         window.addEventListener( "keydown", this.keydownHandler );
     },
-    beforeDestroy() {
+    beforeUnmount() {
         window.removeEventListener( "keydown", this.keydownHandler );
     },
     methods: {

--- a/src/components/song-browser/song-browser.vue
+++ b/src/components/song-browser/song-browser.vue
@@ -93,6 +93,7 @@ type WrappedSongEntry = EffluxSong & {
 };
 
 export default {
+    emits: ["close"],
     i18n: { messages, sharedMessages },
     components: {
         FileLoader,

--- a/src/components/song-creation-window/song-creation-window.vue
+++ b/src/components/song-creation-window/song-creation-window.vue
@@ -61,6 +61,7 @@ import { EffluxSongType } from "@/model/types/song";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     created(): void {
         this.setPlaying( false );

--- a/src/components/song-save-window/song-save-window.vue
+++ b/src/components/song-save-window/song-save-window.vue
@@ -92,6 +92,7 @@ import { ToggleButton } from "vue-js-toggle-button";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     components: {
         ToggleButton,

--- a/src/components/transport/transport.vue
+++ b/src/components/transport/transport.vue
@@ -149,7 +149,6 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
 import { mapState, mapGetters, mapMutations } from "vuex";
 import Bowser from "bowser";
 import PatternOrderList from "@/components/pattern-order-list/pattern-order-list.vue";
@@ -251,7 +250,7 @@ export default {
                         while ( i-- ) {
                             event = events[ i ];
                             if ( event ) {
-                                Vue.set( event, "recording", false );
+                                event["recording"] = false;
                             }
                         }
                     });

--- a/src/components/transposition-editor/transposition-editor.vue
+++ b/src/components/transposition-editor/transposition-editor.vue
@@ -79,6 +79,7 @@ import createAction from "@/model/factories/action-factory";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     data: () => ({
         firstPattern : 1,
@@ -119,7 +120,7 @@ export default {
             this.$refs.semitoneInput.focus();
         });
     },
-    beforeDestroy() {
+    beforeUnmount() {
         this.suspendKeyboardService( false );
     },
     methods: {

--- a/src/components/waveform-display/waveform-display.vue
+++ b/src/components/waveform-display/waveform-display.vue
@@ -61,6 +61,7 @@ const INSTRUMENT_COLORS = [
 ];
 
 export default {
+    emits: ["invalidate"],
     components: {
         SampleDisplay,
     },
@@ -212,7 +213,7 @@ export default {
             this.token = PubSubService.subscribe( Messages.AUDIO_CONTEXT_READY, this.handleAnalysis.bind( this ));
         }
     },
-    beforeDestroy(): void {
+    beforeUnmount(): void {
         if ( this.performAnalysis ) {
             this.disconnectAnalyser();
         }

--- a/src/components/welcome-window/welcome-window.vue
+++ b/src/components/welcome-window/welcome-window.vue
@@ -90,6 +90,7 @@ import { PROPERTIES } from "@/store/modules/settings-module";
 import messages from "./messages.json";
 
 export default {
+    emits: ["close"],
     i18n: { messages },
     components: {
         FileLoader,

--- a/src/efflux-application.vue
+++ b/src/efflux-application.vue
@@ -113,9 +113,8 @@
 
 <script lang="ts">
 import { mapState, mapGetters, mapMutations, mapActions } from "vuex";
-import Vue, { type Component } from "vue";
-import Vuex from "vuex";
-import VueI18n from "vue-i18n";
+import { type Component } from "vue";
+import * as Vuex from "vuex";
 import Bowser from "bowser";
 import Pubsub from "pubsub-js";
 import AudioService, { getAudioContext } from "@/services/audio-service";
@@ -133,12 +132,10 @@ import { readClipboardFiles, readDroppedFiles, readTextFromFile } from "@/utils/
 import { deserializePatternFile } from "@/utils/pattern-util";
 import store from "@/store";
 import messages from "@/messages.json";
-
-Vue.use( Vuex );
-Vue.use( VueI18n );
+import { createI18n } from "vue-i18n";
 
 // Create VueI18n instance with options
-const i18n = new VueI18n({
+const i18n = createI18n({
     messages
 });
 
@@ -165,7 +162,7 @@ function asyncComponent( key: string, importFn: () => Promise<any> ): IAsyncComp
 
 export default {
     name: "Efflux",
-    store: new Vuex.Store( store ),
+    store: Vuex.createStore(store),
     i18n,
     components: {
         DialogWindow: () => asyncComponent( "dw", () => import( "@/components/dialog-window/dialog-window.vue" )),

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,5 @@
-import Vue from "vue";
+import * as Vue from "vue";
 import Efflux from "./efflux-application.vue";
 
-Vue.config.productionTip = false;
-
-new Vue({
-    render: h => h( Efflux )
-}).$mount( "#app" );
+const app = Vue.createApp(Efflux);
+app.mount("#app");

--- a/src/model/actions/channel-solo.ts
+++ b/src/model/actions/channel-solo.ts
@@ -20,7 +20,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Store } from "vuex";
+import type { Store, createStore } from "vuex";
 import type { IUndoRedoState } from "@/model/factories/history-state-factory";
 import type { Instrument } from "@/model/types/instrument";
 import AudioService from "@/services/audio-service";

--- a/src/model/actions/event-actions.ts
+++ b/src/model/actions/event-actions.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import EventFactory from "@/model/factories/event-factory";
 import { type EffluxAudioEvent, ACTION_NOTE_OFF } from "@/model/types/audio-event";
@@ -43,7 +42,7 @@ export function createNoteOffEvent( channelIndex: number ): EffluxAudioEvent {
 export function insertEvent( event: EffluxAudioEvent, song: EffluxSong, patternIndex: number, channelIndex: number, step: number ): void {
     const pattern = song.patterns[ patternIndex ];
     EventUtil.setPosition( event, pattern, step, song.meta.tempo );
-    Vue.set( pattern.channels[ channelIndex ], step, event );
+    pattern.channels[ channelIndex ][step] = event;
 }
 
 /**

--- a/src/model/actions/event-add.ts
+++ b/src/model/actions/event-add.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import type { IUndoRedoState } from "@/model/factories/history-state-factory";
 import { type EffluxAudioEvent, EffluxAudioEventModuleParams, ACTION_NOTE_ON, ACTION_NOTE_OFF } from "@/model/types/audio-event";
@@ -91,11 +90,11 @@ export default function( store: Store<EffluxState>, event: EffluxAudioEvent,
             existingEventMp = serialize(( channel[ step ] as EffluxAudioEvent ).mp );
 
             if ( event.action !== ACTION_NOTE_OFF && !event.mp && existingEventMp ) {
-                Vue.set( event, "mp", deserialize( existingEventMp ));
+                event["mp"] = deserialize( existingEventMp );
             }
             EventUtil.clearEvent( song, patternIndex, channelIndex, step );
         }
-        Vue.set( channel, step, event );
+        channel[step] = event;
 
         if ( length > 1 ) {
             for ( let i = step + 1; i <= eventEnd; ++i ) {
@@ -145,7 +144,7 @@ export default function( store: Store<EffluxState>, event: EffluxAudioEvent,
         undo(): void {
             if ( length > 1 ) {
                 // clone() is necessary to avoid conflicts when stepping the history state back and forth
-                Vue.set( song.patterns[ patternIndex ].channels, channelIndex, clone( orgContent ));
+                song.patterns[ patternIndex ].channels[channelIndex] = clone( orgContent );
             } else {
                 EventUtil.clearEvent(
                     song,

--- a/src/model/actions/event-move.ts
+++ b/src/model/actions/event-move.ts
@@ -1,27 +1,4 @@
-/**
- * The MIT License (MIT)
- *
- * Igor Zinken 2023 - https://www.igorski.nl
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-import Vue from "vue";
-import type { Store } from "vuex";
+import type { Store, createStore } from "vuex";
 import type { IUndoRedoState } from "@/model/factories/history-state-factory";
 import { type EffluxAudioEvent, ACTION_NOTE_ON } from "@/model/types/audio-event";
 import { EffluxSongType } from "@/model/types/song";
@@ -91,7 +68,7 @@ export default function( store: Store<EffluxState>,
     return {
         undo(): void {
             // clone() is necessary to avoid conflicts when stepping the history state back and forth
-            Vue.set( song.patterns[ patternIndex ].channels, channelIndex, clone( orgContent ));
+            song.patterns[ patternIndex ].channels[channelIndex] = clone( orgContent );
             invalidateCache( store, song, channelIndex );
         },
         redo: act

--- a/src/model/actions/event-resize.ts
+++ b/src/model/actions/event-resize.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import type { IUndoRedoState } from "@/model/factories/history-state-factory";
 import { ACTION_NOTE_ON } from "@/model/types/audio-event";
@@ -71,7 +70,7 @@ export default function( store: Store<EffluxState>, patternIndex: number, channe
     return {
         undo(): void {
             // clone() is necessary to avoid conflicts when stepping the history state back and forth
-            Vue.set( song.patterns[ patternIndex ].channels, channelIndex, clone( orgContent ));
+            song.patterns[ patternIndex ].channels[channelIndex] = clone( orgContent );
             invalidateCache( store, song, channelIndex );
         },
         redo: act,

--- a/src/model/factories/action-factory.ts
+++ b/src/model/factories/action-factory.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store, ActionContext } from "vuex";
 import Config from "@/config";
 import Actions from "@/definitions/actions";
@@ -111,11 +110,11 @@ function addMultipleEventsAction({ store, events } : { store: Store<EffluxState>
                 const stepEntry = channel[ step ] as EffluxAudioEvent;
 
                 if ( event.action !== ACTION_NOTE_OFF && !event.mp && stepEntry.mp ) {
-                    Vue.set( event, "mp", clone( stepEntry.mp ));
+                    event["mp"] = clone( stepEntry.mp );
                 }
                 EventUtil.clearEvent( song, patternIndex, targetIndex, step );
             }
-            Vue.set( channel, step, event );
+            channel[step] = event;
         });
     }
     act(); // perform action
@@ -135,7 +134,7 @@ function addMultipleEventsAction({ store, events } : { store: Store<EffluxState>
                 const existingEvent: EffluxAudioEvent = existingEvents[ index ];
                 if ( existingEvent ) {
                     const restoredEvent = deserialize( existingEvent );
-                    Vue.set( song.patterns[ patternIndex ].channels[ targetIndex ], step, restoredEvent );
+                    song.patterns[ patternIndex ].channels[ targetIndex ][step] = restoredEvent;
                 }
             });
         },
@@ -146,31 +145,31 @@ function addMultipleEventsAction({ store, events } : { store: Store<EffluxState>
 function addModuleAutomationAction({ event, mp }: { event: EffluxAudioEvent, mp: EffluxAudioEventModuleParams }): IUndoRedoState {
     const automationData     = serialize( mp );
     const existingAutomation = serialize( event.mp );
-    const act = () => Vue.set( event, "mp", deserialize( automationData ));
+    const act = () => event["mp"] = deserialize( automationData );
 
     act(); // perform action
 
     return {
         undo(): void {
             if ( existingAutomation ) {
-                Vue.set( event, "mp", deserialize( existingAutomation ));
+                event["mp"] = deserialize( existingAutomation );
             } else {
-                Vue.delete( event, "mp" );
+                delete event["mp"];
             }
         },
         redo: act
-    }
+    };
 }
 
 function deleteModuleAutomationAction({ event }: { event: EffluxAudioEvent }): IUndoRedoState {
     const existingAutomation = serialize( event.mp );
-    const act = () => Vue.delete( event, "mp" );
+    const act = () => delete event["mp"];
 
     act(); // perform action
 
     return {
         undo(): void {
-            Vue.set( event, "mp", deserialize( existingAutomation ));
+            event["mp"] = deserialize( existingAutomation );
         },
         redo: act
     };
@@ -195,7 +194,7 @@ function cutSelectionAction({ store }: { store: Store<EffluxState> }): IUndoRedo
     let cutPattern: EffluxPattern;
     function act(): void {
         if ( cutPattern ) {
-            Vue.set( song.patterns, activePattern, cutPattern );
+            song.patterns[activePattern] = cutPattern;
         }
         else {
             commit( "cutSelection", { song, activePattern });
@@ -209,7 +208,7 @@ function cutSelectionAction({ store }: { store: Store<EffluxState> }): IUndoRedo
     return {
         undo(): void {
             // set the original pattern data back
-            Vue.set( song.patterns, activePattern, originalPattern );
+            song.patterns[activePattern] = originalPattern;
 
             // restore selection model to previous state
             commit( "setMinSelectedStep", selectedMinStep);
@@ -236,7 +235,7 @@ function deleteSelectionAction({ store }: { store: Store<EffluxState> }): IUndoR
     let cutPattern: EffluxPattern;
     function act(): void {
         if ( cutPattern ) {
-            Vue.set( song.patterns, activePattern, cutPattern );
+            song.patterns[activePattern] = cutPattern;
         } else {
             commit( "deleteSelection", { song, activePattern });
             cutPattern = clonePattern( song, activePattern );
@@ -249,7 +248,7 @@ function deleteSelectionAction({ store }: { store: Store<EffluxState> }): IUndoR
     return {
         undo(): void {
             // set the original pattern data back
-            Vue.set( song.patterns, activePattern, originalPattern );
+            song.patterns[activePattern] = originalPattern;
 
             // restore selection model to previous state
             commit( "setMinSelectedStep", selectedMinStep);
@@ -278,7 +277,7 @@ function pasteSelectionAction({ store }: { store: Store<EffluxState> }): IUndoRe
     let pastedPattern: EffluxPattern;
     function act(): void {
         if ( pastedPattern ) {
-            Vue.set( song.patterns, activePattern, pastedPattern );
+            song.patterns[activePattern] = pastedPattern;
         } else {
             commit( "pasteSelection", { song, activePattern, selectedInstrument, selectedStep });
             pastedPattern = clonePattern( song, activePattern );
@@ -290,7 +289,7 @@ function pasteSelectionAction({ store }: { store: Store<EffluxState> }): IUndoRe
     return {
         undo(): void {
             // set the original pattern data back
-            Vue.set( song.patterns, activePattern, originalPattern );
+            song.patterns[activePattern] = originalPattern;
 
             // we can safely override the existing selection of the model when undoing an existing paste
             // this means we are returning the model to the state prior to the pasting

--- a/src/services/audio/metronome.ts
+++ b/src/services/audio/metronome.ts
@@ -20,8 +20,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import { beep } from "./webaudio-helper";
+import { reactive } from "vue";
 
 /**
  * Metronome is a component of the transporter
@@ -29,7 +29,7 @@ import { beep } from "./webaudio-helper";
  */
 export default
 {
-    enabled : Vue.observable({
+    enabled : reactive({
         value: false
     }),
     restore         : false,

--- a/src/services/keyboard/instrument-selection-handler.ts
+++ b/src/services/keyboard/instrument-selection-handler.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import Config from "@/config";
 import type { EffluxState } from "@/store";
@@ -50,7 +49,7 @@ export default {
             if ( event ) {
                 // note we subtract 1 as we store the instrument by index in the model, but
                 // visualize it starting from 1 as humans love that.
-                Vue.set( event, "instrument", keyCode - ONE );
+                event["instrument"] = keyCode - ONE;
             }
         }
     }

--- a/src/services/keyboard/module-param-handler.ts
+++ b/src/services/keyboard/module-param-handler.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import Actions from "@/definitions/actions";
 import EventFactory from "@/model/factories/event-factory";
@@ -79,7 +78,7 @@ const ModuleParamHandler =
         );
 
         if ( createEvent ) {
-            Vue.set( event, "mp", mp );
+            event["mp"] = mp;
         } else {
             // a previously existed event will register the mp change in state history
             // (a newly created event is added to state history through its addition to the song)

--- a/src/services/keyboard/module-value-handler.ts
+++ b/src/services/keyboard/module-value-handler.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import Actions from "@/definitions/actions";
 import EventFactory from "@/model/factories/event-factory";
@@ -105,7 +104,7 @@ export default {
         }
 
         if ( createEvent ) {
-            Vue.set( event, "mp", mp );
+            event["mp"] = mp;
         } else {
             // a previously existed event will register the mp change in state history
             // (a newly created event is added to state history through its addition to the song)

--- a/src/store/modules/selection-module.ts
+++ b/src/store/modules/selection-module.ts
@@ -21,7 +21,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import type { Module } from "vuex";
-import Vue from "vue";
 import { writeToClipboard } from "@/utils/clipboard-util";
 import EventUtil from "@/utils/event-util";
 import { clone } from "@/utils/object-util";
@@ -339,7 +338,7 @@ const SelectionModule: Module<SelectionState, any> = {
                                 clonedEvent.seq.playing = false;
 
                                 EventUtil.setPosition( clonedEvent, targetPattern, writeIndex, song.meta.tempo );
-                                Vue.set( targetChannel, writeIndex, clonedEvent );
+                                targetChannel[writeIndex] = clonedEvent;
                             }
                         }
                     });

--- a/src/store/modules/sequencer-module.ts
+++ b/src/store/modules/sequencer-module.ts
@@ -21,7 +21,6 @@
 * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 import type { Module, Store, Commit } from "vuex";
-import Vue from "vue";
 import Config from "@/config";
 import LinkedList from "@/utils/linked-list";
 import { noteOn, noteOff, getAudioContext, isRecording, togglePlayback } from "@/services/audio-service";
@@ -559,12 +558,12 @@ const SequencerModule: Module<SequencerState, any> = {
                        transformed[ j ] = channel[ i ];
                     }
                 }
-                Vue.set( pattern.channels, index, transformed );
-                Vue.set( pattern, "steps", steps );
+                pattern.channels[index] = transformed;
+                pattern["steps"] = steps;
             });
         },
         setJamChannelLock( state: SequencerState, { instrumentIndex, locked } : { instrumentIndex: number, locked: boolean }): void {
-            Vue.set( state.jam, instrumentIndex, { ...state.jam[ instrumentIndex ], locked });
+            state.jam[instrumentIndex] = { ...state.jam[ instrumentIndex ], locked };
         },
         setJamChannelPosition( state: SequencerState, { instrumentIndex, patternIndex }: { instrumentIndex: number, patternIndex: number }): void {
             if ( state.jam[ instrumentIndex ].locked ) {
@@ -575,7 +574,7 @@ const SequencerModule: Module<SequencerState, any> = {
             if ( !state.playing ) {
                 activePatternIndex = nextPatternIndex;
             }
-            Vue.set( state.jam, instrumentIndex, { activePatternIndex, nextPatternIndex });
+            state.jam[instrumentIndex] = { activePatternIndex, nextPatternIndex };
         },
         resetJamChannels( state: SequencerState ): void {
             for ( let i = 0; i < state.jam.length; ++i ) {

--- a/src/store/modules/settings-module.ts
+++ b/src/store/modules/settings-module.ts
@@ -21,7 +21,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import type { Commit, Dispatch, Module } from "vuex";
-import Vue from "vue";
 import Config from "@/config";
 import { EffluxSongType } from "@/model/types/song";
 import StorageUtil from "@/utils/storage-util";
@@ -78,7 +77,7 @@ const SettingsModule: Module<SettingsState, any> = {
     },
     mutations: {
         saveSetting( state: SettingsState, { name, value }: { name: string, value: any }): void {
-            Vue.set( state._settings, name, value );
+            state._settings[name] = value;
             persistState( state );
         },
         setStoredSettings( state: SettingsState, settings: any ): void {

--- a/src/store/modules/song-module.ts
+++ b/src/store/modules/song-module.ts
@@ -21,7 +21,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import type { ActionContext, Commit, Dispatch, Module, Store } from "vuex";
-import Vue from "vue";
 import Config from "@/config";
 import { PROJECT_FILE_EXTENSION } from "@/definitions/file-types";
 import ModalWindows from "@/definitions/modal-windows";
@@ -122,7 +121,7 @@ const SongModule: Module<SongState, any> = {
         },
         updateSongSample( state: SongState, sample: Sample ): void {
             const index = state.activeSong.samples.findIndex(({ id }) => id === sample.id );
-            Vue.set( state.activeSong.samples, index, sample );
+            state.activeSong.samples[index] = sample;
         },
         /**
          * adds given AudioEvent at the currently highlighted position or by optionally defined
@@ -154,24 +153,24 @@ const SongModule: Module<SongState, any> = {
             }
         },
         updateOscillator( state: SongState, { instrumentIndex, oscillatorIndex, prop, value } : { instrumentIndex: number, oscillatorIndex: number, prop: string, value: any }): void {
-            Vue.set( state.activeSong.instruments[ instrumentIndex ].oscillators[ oscillatorIndex ], prop, value );
+            state.activeSong.instruments[ instrumentIndex ].oscillators[ oscillatorIndex ][prop] = value;
         },
         updateInstrument( state: SongState, { instrumentIndex, prop, value } : { instrumentIndex: number, prop: string, value: any }): void {
-            Vue.set( state.activeSong.instruments[ instrumentIndex ], prop, value );
+            state.activeSong.instruments[ instrumentIndex ][prop] = value;
         },
         replaceInstrument( state: SongState, { instrumentIndex, instrument }: { instrumentIndex: number, instrument: Instrument }): void {
-            Vue.set( state.activeSong.instruments, instrumentIndex, instrument );
+            state.activeSong.instruments[instrumentIndex] = instrument;
         },
         replacePattern( state: SongState, { patternIndex, pattern }: { patternIndex: number, pattern: EffluxPattern }): void {
-            Vue.set( state.activeSong.patterns, patternIndex, pattern );
+            state.activeSong.patterns[patternIndex] = pattern;
             cachePatternNames( state.activeSong.patterns );
         },
         replacePatterns( state: SongState, patterns: EffluxPattern[] ): void {
             cachePatternNames( patterns );
-            Vue.set( state.activeSong, "patterns", patterns );
+            state.activeSong["patterns"] = patterns;
         },
         replacePatternOrder( state: SongState, order: EffluxPatternOrder ): void {
-            Vue.set( state.activeSong, "order", order );
+            state.activeSong["order"] = order;
         },
         cachePatternNames( state: SongState ): void {
             cachePatternNames( state.activeSong.patterns );

--- a/src/utils/event-util.ts
+++ b/src/utils/event-util.ts
@@ -20,7 +20,6 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Vue from "vue";
 import type { Store } from "vuex";
 import EventFactory from "@/model/factories/event-factory";
 import { type EffluxAudioEvent, type EffluxAudioEventModuleParams, ACTION_IDLE, ACTION_NOTE_ON, ACTION_NOTE_OFF } from "@/model/types/audio-event";
@@ -47,7 +46,7 @@ const EventUtil =
         const measureLength = calculateMeasureLength( tempo );
         const eventOffset   = ( patternStep / pattern.steps ) * measureLength;
       
-        Vue.set( event.seq, "startMeasureOffset", eventOffset );
+        event.seq["startMeasureOffset"] = eventOffset;
     },
     /**
      * clears the AudioEvent at requested step position in
@@ -57,7 +56,7 @@ const EventUtil =
         const pattern = song.patterns[ patternIndex ];
         const channel = pattern.channels[ channelIndex ];
 
-        Vue.set( channel, step, 0 );
+        channel[step] = 0;
     },
     /**
      * Brute force way to remove an event from a song
@@ -146,8 +145,8 @@ const EventUtil =
 
         // ensure events glide their module parameter change
 
-        Vue.set( firstParam,  "glide", true );
-        Vue.set( secondParam, "glide", true );
+        firstParam["glide"] = true;
+        secondParam["glide"] = true;
 
         // find distance (in steps) between these two events
         // TODO: keep patterns' optional resolution differences in mind
@@ -158,14 +157,14 @@ const EventUtil =
             if ( typeof evt !== "object" ) {
                 // event didn't exist... create it, insert into the channel
                 evt = EventFactory.create( firstEvent.instrument );
-                Vue.set( channel, eventIndex, evt );
+                channel[eventIndex] = evt;
                 EventUtil.setPosition( evt, pattern, eventIndex, song.meta.tempo );
             }
-            Vue.set( evt, "mp", {
+            evt["mp"] = {
                 module: firstEvent.mp.module,
                 value: 0,
                 glide: true
-            });
+            };
             return evt;
         };
 
@@ -196,7 +195,7 @@ const EventUtil =
             increment = ( secondParam.value - firstParam.value ) / steps;
             events.forEach(( event: EffluxAudioEvent, index: number ): void => {
                 const mp = event.mp;
-                Vue.set( mp, "value", firstParam.value + (( index + 1 ) * increment));
+                mp["value"] = firstParam.value + (( index + 1 ) * increment);
             });
         }
         else {
@@ -204,7 +203,7 @@ const EventUtil =
             increment = ( secondParam.value - firstParam.value ) / steps;
             events.forEach(( event: EffluxAudioEvent, index: number ): void => {
                 const mp = event.mp;
-                Vue.set( mp, "value", firstParam.value + (( index + 1 ) * increment ));
+                mp["value"] = firstParam.value + (( index + 1 ) * increment );
             });
         }
         return events;
@@ -242,7 +241,7 @@ const EventUtil =
                         if ( event.note === "" ) {
                             EventUtil.clearEventByReference( song, event );
                         } else {
-                            Vue.set( event, "mp", null );
+                            event["mp"] = null;
                         }
                     });
                 },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-import vue from "@vitejs/plugin-vue2";
+import vue from "@vitejs/plugin-vue";
 import path from "path";
 
 const dirSrc      = `./src`;


### PR DESCRIPTION
This is a draft PR that deals with several of the chore parts of migrating a Vue 2 app to Vue 3 such as emits and changing lifecycle hook methods.
There are dependencies such as `vue-js-toggle-button` which are not compatible with Vue 3 that still need to be dealt with.